### PR TITLE
ECS base structure

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -1,0 +1,12 @@
+{
+	"name": "valhala_ecs",
+	"description": "A simple, easy-to-use yet robust ecs lib in D",
+	"importPaths": ["source"],
+	"sourcePaths": ["source"],
+	"targetPath": "bin",
+	"license": "MIT",
+	"targetType": "library",
+	"dependencies": {
+		"aurorafw:unit": "~>0.0.1-alpha.4"
+	}
+}

--- a/dub.selections.json
+++ b/dub.selections.json
@@ -1,0 +1,6 @@
+{
+	"fileVersion": 1,
+	"versions": {
+		"aurorafw": "0.0.1-alpha.4"
+	}
+}

--- a/source/ecs/entity.d
+++ b/source/ecs/entity.d
@@ -1,0 +1,387 @@
+module ecs.entity;
+
+import std.exception : basicExceptionCtors, enforce;
+import std.typecons : Nullable;
+
+version(unittest) import aurorafw.unit.assertion;
+
+
+/**
+ * EntityType is defined as being an integral and unsigned value. Possible
+ *     type are **ubyte, ushort, uint, ulong, size_t**. All remaining type are
+ *     defined as being invalid.
+ *
+ * Params: T = type to classify.
+ *
+ * Returns: true if it's a valid type, false otherwise.
+ */
+private template isEntityType(T)
+{
+	import std.traits : isIntegral, isUnsigned;
+	enum isEntityType = isIntegral!T && isUnsigned!T;
+}
+
+///
+@safe
+@("entity: isEntityType")
+unittest
+{
+	import std.meta : AliasSeq, allSatisfy;
+	assertTrue(allSatisfy!(isEntityType, AliasSeq!(ubyte, ushort, uint, ulong, size_t)));
+
+	assertFalse(allSatisfy!(isEntityType, AliasSeq!(byte, short, int, long, ptrdiff_t)));
+	assertFalse(allSatisfy!(isEntityType, AliasSeq!(float, double, real, ifloat, idouble, ireal)));
+	assertFalse(allSatisfy!(isEntityType, AliasSeq!(char, dchar, wchar, string, bool)));
+}
+
+
+/**
+ * Defines ground constants used to manipulate entities internaly.
+ *
+ * Constants:
+ *     `entityShift` = division point between the entity's **id** and **batch**. \
+ *     `entityMask` = bit mask related to the entity's **id** portion. \
+ *     `batchMask` = bit mask related to the entity's **batch** portion. \
+ *     `entityNull` = Entity!(T) with an **id** of the max value available for T.
+ *
+ * Code_Gen:
+ * | type   | entityShift | entityMask  | batchMask   | entityNull                    |
+ * | :------| :---------: | :---------- | :---------- | :---------------------------- |
+ * | ubyte  | 4           | 0xF         | 0xF         | Entity!(ubyte)(15)            |
+ * | ushort | 8           | 0xFF        | 0xFF        | Entity!(ushort)(255)          |
+ * | uint   | 20          | 0xFFFF_F    | 0xFFF       | Entity!(uint)(1_048_575)      |
+ * | ulong  | 32          | 0xFFFF_FFFF | 0xFFFF_FFFF | Entity!(ulong)(4_294_967_295) |
+ *
+ * Sizes:
+ * | type   | id-(bits) | batch-(bits) | max-entities  | batch-reset   |
+ * | :----- | :-------: | :----------: | :-----------: | :-----------: |
+ * | ubyte  | 4         | 4            | 14            | 15            |
+ * | ushort | 8         | 8            | 254           | 255           |
+ * | uint   | 20        | 12           | 1_048_574     | 4_095         |
+ * | ulong  | 32        | 32           | 4_294_967_295 | 4_294_967_295 |
+ *
+ * Params: T = valid entity type.
+ */
+private mixin template genBitMask(T)
+	if (isEntityType!T)
+{
+	static if (is(T == uint))
+	{
+		enum T entityShift = 20U;
+		enum T entityMask = (1UL << 20U) - 1;
+		enum T batchMask = (1UL << (T.sizeof * 8 - 20U)) - 1;
+	}
+	else
+	{
+		enum T entityShift = T.sizeof * 8 / 2;
+		enum T entityMask = (1UL << T.sizeof * 8 / 2) - 1;
+		enum T batchMask = (1UL << (T.sizeof * 8 - T.sizeof * 8 / 2)) - 1;
+	}
+
+	enum Entity!T entityNull = Entity!T(entityMask);
+}
+
+///
+@safe
+@("entity: genBitMask")
+unittest
+{
+	{
+		mixin genBitMask!uint;
+		assertTrue(is(typeof(entityShift) == uint));
+
+		assertEquals(20, entityShift);
+		assertEquals(0xFFFF_F, entityMask);
+		assertEquals(0xFFF, batchMask);
+		assertEquals(Entity!uint(entityMask), entityNull);
+	}
+
+	{
+		mixin genBitMask!ulong;
+		assertTrue(is(typeof(entityShift) == ulong));
+
+		assertEquals(32, entityShift);
+		assertEquals(0xFFFF_FFFF, entityMask);
+		assertEquals(0xFFFF_FFFF, batchMask);
+		assertEquals(Entity!ulong(entityMask), entityNull);
+	}
+}
+
+
+class MaximumEntitiesReachedException : Exception { mixin basicExceptionCtors; }
+
+
+/**
+ * Defines an entity of entity type T. An entity is defined by an **id** and a
+ *     **batch**. It's signature is the combination of both values. The first N
+ *     bits belong to the **id** and the last M ending bits to the `batch`. \
+ * \
+ * An entity in it's raw form is simply a value of entity type T formed by the
+ *     junction of the id with the batch. The constant values which define all
+ *     masks are calculated in the `genBitMask` mixin template. \
+ * \
+ * An entity is then defined by: **id | (batch << entity_shift)**. \
+ * \
+ * Let's imagine an entity of the ubyte type. By default it's **id** and **batch**
+ *     occupy **4 bits** each, half the sizeof ubyte. \
+ * \
+ * `Entity!ubyte` = **0000 0000** = ***(batch << 4) | id***.
+ * \
+ * What this means is that for a given value of `ubyte` it's first half is
+ *     composed with the **id** and it's second half with the **batch**. This
+ *     allows entities to be reused at some time in the program's life without
+ *     having to resort to a more complicated process. Every time an entity is
+ *     **discarded** it's **id** doesn't suffer any alterations however it's
+ *     **batch** is increased by **1**, allowing the usage of an entity with the
+ *     the same **id** but mantaining it's uniqueness with a new **batch**
+ *     generating a completely new signature.
+ *
+ * See_Also: [skypjack - entt](https://skypjack.github.io/2019-05-06-ecs-baf-part-3/)
+ */
+@safe
+struct Entity(T)
+	if (isEntityType!T)
+{
+public:
+	this(in T id) { _id = id; }
+	this(in T id, in T batch) { _id = id; _batch = batch; }
+
+	bool opEquals(in Entity other) const
+	{
+		return other.signature == signature;
+	}
+
+	@property
+	T id() const { return _id; }
+
+	@property
+	T batch() const { return _batch; }
+
+	auto incrementBatch()
+	{
+		_batch = _batch >= EntityManager!(T).batchMask ? 0 : cast(T)(_batch + 1);
+
+		return this;
+	}
+
+	T signature() const
+	{
+		return cast(T)(_id | (_batch << EntityManager!(T).entityShift));
+	}
+
+private:
+	T _id;
+	T _batch;
+}
+
+@safe
+@("entity: Entity")
+unittest
+{
+	auto entity0 = Entity!ubyte(0);
+
+	assertEquals(0, entity0.id);
+	assertEquals(0, entity0.batch);
+	assertEquals(0, entity0.signature);
+	assertEquals(Entity!ubyte(0, 0), entity0);
+
+	entity0.incrementBatch();
+	assertEquals(0, entity0.id);
+	assertEquals(1, entity0.batch);
+	assertEquals(16, entity0.signature);
+	assertEquals(Entity!ubyte(0, 1), entity0);
+
+	entity0 = Entity!ubyte(0, 15);
+	entity0.incrementBatch();
+	assertEquals(0, entity0.batch); // batch reseted
+
+	assertEquals(15, Entity!ubyte(0, 15).batch);
+}
+
+
+/**
+ * Responsible for managing all entities lifetime and access to components as
+ *     well as any operation related to them.
+ *
+ * Params: T = valid entity type.
+ */
+class EntityManager(T)
+{
+public:
+	mixin genBitMask!T;
+
+
+	this() { queue = entityNull; }
+
+
+	/**
+	 * Generates a new entity either by fabricating a new one or by recycling an
+	 *     previously fabricated if the queue is not null. Throws a
+	 *     **MaximumEntitiesReachedException** if the amount of entities alive
+	 *     allowed reaches it's maximum value.
+	 *
+	 * Returns: a newly generated Entity!T.
+	 *
+	 * Throws: `MaximumEntitiesReachedException`.
+	 */
+	@safe
+	Entity!(T) gen()
+	{
+		return queue.isNull ? fabricate() : recycle();
+	}
+
+
+	/**
+	 * Makes a valid entity invalid. When an entity is discarded it's **swapped**
+	 *     with the current entity in the **queue** and it's **batch** is
+	 *     incremented. The operation is aborted when trying to discard an
+	 *     invalid entity.
+	 *
+	 * Params: entity = valid entity to discard.
+	 *
+	 * Returns: true if successful, false otherwise.
+	 */
+	@safe
+	bool discard(in Entity!(T) entity)
+	{
+		// Invalid action if the entity is not valid
+		if (!(entity.id < entities.length && entities[entity.id] == entity))
+			return false;
+
+		entities[entity.id] = queue.isNull ? entityNull : queue ; // move the next in queue to back
+		queue = entity;                                           // update the next in queue
+		queue.incrementBatch();                                   // increment batch for when it's revived
+		return true;
+	}
+
+private:
+	/**
+	 * Creates a new entity with a new id. The entity's id follows the total
+	 *     value of entities created. Throws a **MaximumEntitiesReachedException**
+	 *     if the maximum amount of entities allowed is reached.
+	 *
+	 * Returns: an Entity!T with a new id.
+	 *
+	 * Throws: `MaximumEntitiesReachedException`.
+	 */
+	@safe
+	Entity!(T) fabricate()
+	{
+		import std.format : format;
+		enforce!MaximumEntitiesReachedException(
+			entities.length < entityMask,
+			format!"Reached the maximum amount of entities supported for type %s: %s!"(T.stringof, entityMask)
+		);
+
+		import std.range : back;
+		entities ~= Entity!(T)(cast(T)entities.length); // safe cast
+		return entities.back;
+	}
+
+
+	/**
+	 * Creates a new entity reusing a **previously discarded entity** with a new
+	 *     **batch**. Swaps the current discarded entity stored the queue's entity
+	 *     place with it.
+	 *
+	 * Returns: an Entity!T previously fabricated with a new batch.
+	 */
+	@safe
+	Entity!(T) recycle()
+		in (!queue.isNull)
+	{
+		immutable next = queue;     // get the next entity in queue
+		queue = entities[next.id];  // grab the entity which will be the next in queue
+		entities[next.id] = next;   // revive the entity
+		return next;
+	}
+
+
+	Entity!(T)[] entities;
+	Nullable!(Entity!(T), entityNull) queue;
+}
+
+
+@safe
+@("entity: EntityManager")
+unittest
+{
+	assertTrue(__traits(compiles, EntityManager!uint));
+	assertFalse(__traits(compiles, EntityManager!int));
+}
+
+@safe
+@("entity: EntityManager: discard")
+unittest
+{
+	auto em = new EntityManager!uint();
+	assertTrue(em.queue.isNull);
+
+	auto entity0 = em.gen();
+	auto entity1 = em.gen();
+	auto entity2 = em.gen();
+
+
+	em.discard(entity1);
+	assertFalse(em.queue.isNull);
+	assertEquals(em.entityNull, em.entities[entity1.id]);
+	(() @trusted => assertEquals(Entity!uint(1, 1), em.queue))(); // batch was incremented
+
+	assertTrue(em.discard(entity0));
+	assertEquals(Entity!uint(1, 1), em.entities[entity0.id]);
+	(() @trusted => assertEquals(Entity!uint(0, 1), em.queue))(); // batch was incremented
+
+	// cannot discard invalid entities
+	assertFalse(em.discard(Entity!uint(50)));
+	assertFalse(em.discard(Entity!uint(entity2.id, 40)));
+
+	assertEquals(3, em.entities.length);
+}
+
+@safe
+@("entity: EntityManager: fabricate")
+unittest
+{
+	import std.range : back;
+	auto em = new EntityManager!ubyte();
+
+	auto entity0 = em.gen(); // calls fabricate
+	em.discard(entity0); // discards
+	em.gen(); // recycles
+	assertTrue(em.queue.isNull);
+
+	assertEquals(Entity!(ubyte)(1), em.gen()); // calls fabricate again
+	assertEquals(2, em.entities.length);
+	assertEquals(Entity!(ubyte)(1), em.entities.back);
+
+	em.entities.length = 15; // max entities allowed for ubyte
+	expectThrows!MaximumEntitiesReachedException(em.gen());
+}
+
+@safe
+@("entity: EntityManager: gen")
+unittest
+{
+	import std.range : front;
+	auto em = new EntityManager!uint();
+
+	assertEquals(Entity!(uint)(0), em.gen());
+	assertEquals(1, em.entities.length);
+	assertEquals(Entity!(uint)(0), em.entities.front);
+}
+
+@safe
+@("entity: EntityManager: recycle")
+unittest
+{
+	import std.range : front;
+	auto em = new EntityManager!uint();
+
+	auto entity0 = em.gen(); // calls fabricate
+	em.discard(entity0); // discards
+	(() @trusted => assertEquals(Entity!uint(0, 1), em.queue))(); // batch was incremented
+	assertFalse(Entity!uint(0, 1) == entity0); // entity's batch is not updated
+
+	entity0 = em.gen(); // recycles
+	assertEquals(Entity!uint(0, 1), em.entities.front);
+}

--- a/source/ecs/entitybuilder.d
+++ b/source/ecs/entitybuilder.d
@@ -1,0 +1,68 @@
+module ecs.entitybuilder;
+
+import ecs.entity;
+
+version(unittest) import aurorafw.unit.assertion;
+
+
+/**
+ * Helper struct to perform multiple actions sequences.
+ *
+ * Params: em = an entity manager to update.
+ *
+ * Returns: an EntityBuilder!EntityType.
+ */
+auto entityBuilder(EntityType)(EntityManager!EntityType em)
+{
+	return EntityBuilder!EntityType(em);
+}
+
+@("entitybuilder: entityBuilder")
+unittest
+{
+	EntityManager!uint em = new EntityManager!uint();
+	auto entitites = em.entityBuilder
+		.gen()
+		.gen()
+		.gen()
+		.get();
+
+	assertEquals([Entity!uint(0), Entity!uint(1), Entity!uint(2)], entitites);
+}
+
+
+/**
+ * Helper struct to perform multiple actions sequences.
+ *
+ * Params:
+ *     EntityType = a valid entity type.
+ *     em = an entity manager to update.
+ */
+struct EntityBuilder(EntityType)
+{
+public:
+	this(EntityManager!EntityType em)
+	{
+		this.em = em;
+	}
+
+
+	@safe
+	auto gen()
+	{
+		entities ~= em.gen();
+		return this;
+	}
+
+
+	@safe
+	auto get() const
+	{
+		return entities;
+	}
+
+
+private:
+	Entity!(EntityType)[] entities;
+	EntityManager!EntityType em;
+}

--- a/source/ecs/storage.d
+++ b/source/ecs/storage.d
@@ -1,0 +1,236 @@
+module ecs.storage;
+
+import ecs.entity : Entity;
+
+version(unittest) import aurorafw.unit.assertion;
+
+/**
+ * A component must define this as an UDA.
+ */
+enum Component;
+
+
+/**
+ * Evalute is some T is a valid component. A component is defined by being a
+ *     **struct** and must have the **Component** UDA.
+ *
+ * Params: T = valid component type.
+ *
+ * Returns: true is is a valid component, false otherwise.
+ */
+template isComponent(T)
+{
+	import std.traits : hasUDA;
+	enum isComponent = is(T == struct) && hasUDA!(T, Component);
+}
+
+version(unittest)
+{
+	@Component struct ValidComponent {}
+	@Component struct OtherValidComponent { int a; }
+	struct InvalidComponent {}
+}
+
+///
+@safe
+@("storage: isComponent")
+unittest
+{
+	assertTrue(isComponent!ValidComponent);
+	assertTrue(isComponent!OtherValidComponent);
+	assertFalse(isComponent!InvalidComponent);
+}
+
+
+template componentId(Component)
+	if (isComponent!Component)
+{
+	enum componentId = typeid(Component);
+}
+
+///
+@safe
+@("storage: componentId")
+unittest
+{
+	assertTrue(__traits(compiles, componentId!ValidComponent));
+	assertTrue(__traits(compiles, componentId!OtherValidComponent));
+	assertFalse(__traits(compiles, componentId!InvalidComponent));
+}
+
+
+/**
+ * Structure to communicate with the Storage. Easier to keep diferent components
+ *     in the same data structure for better access to it's storage. It can also
+ *     have some fast access functions which map directly to the storage's
+ *     functions.
+ *
+ * Params:
+ *     EntityType = a valid entity type
+ *     Component = a valid component
+ */
+package struct StorageInfo(EntityType)
+{
+public:
+	this(Component)()
+	{
+		auto storage = new Storage!(EntityType, Component);
+		this.cid = componentId!Component;
+
+		(() @trusted => this.storage = cast(void*) storage)();
+		this.remove = &storage.remove;
+	}
+
+	Storage!(EntityType, Component) getStorage(Component)()
+	{
+		return cid is componentId!Component
+			? (() @trusted => cast(Storage!(EntityType, Component)) storage)() // safe cast
+			: null;
+	}
+
+	bool delegate(Entity!EntityType entity) remove;
+
+private:
+	TypeInfo cid;
+	void* storage;
+}
+
+@safe
+@("storage: StorageInfo")
+unittest
+{
+	auto sinfo = StorageInfo!(uint)().__ctor!(ValidComponent)();
+
+	assertNotNull(sinfo.getStorage!ValidComponent);
+	assertNull(sinfo.getStorage!OtherValidComponent);
+	assertFalse(__traits(compiles, sinfo.getStorage!InvalidComponent));
+}
+
+@safe
+@("storage: StorageInfo")
+unittest
+{
+	import std.range : front;
+
+	auto sinfo = StorageInfo!(uint)().__ctor!(ValidComponent)();
+	Storage!(uint, ValidComponent) storage = sinfo.getStorage!(ValidComponent);
+
+	assertTrue(storage.add(Entity!uint(0), ValidComponent()));
+	assertEquals(1, storage._packedEntities.length);
+	assertEquals(Entity!uint(0), storage._packedEntities.front);
+
+	assertFalse(storage.remove(Entity!uint(0, 45)));
+	assertTrue(storage.remove(Entity!uint(0)));
+	assertEquals(0, storage._packedEntities.length);
+}
+
+
+/**
+ * Used to save every component of a Component type and to keep track of which
+ *     entities of type EntityType are connected to a component.
+ *
+ * Params:
+ *     EntityType = a valid entity type.
+ *     Component = a valid component.
+ */
+package class Storage(EntityType, Component)
+	if (isComponent!Component)
+{
+	@safe
+	bool add(in Entity!EntityType entity, in Component component)
+	{
+		// don't add if exists one with the same id
+		if (entity.id < _sparsedEntities.length
+			&& _sparsedEntities[entity.id] < _packedEntities.length
+			&& _packedEntities[_sparsedEntities[entity.id]].id == entity.id
+		)
+			return false;
+
+		_packedEntities ~= entity; // add entity
+		_components ~= component; // add component
+
+		// map to the correct entity from the packedEntities from sparsedEntities
+		if (entity.id >= _sparsedEntities.length) _sparsedEntities.length = entity.id + 1;
+		_sparsedEntities[entity.id] = cast(EntityType)(_packedEntities.length - 1); // safe cast
+
+		return true;
+	}
+
+
+	@safe
+	bool remove(in Entity!EntityType entity)
+	{
+		if (!(entity.id < _sparsedEntities.length
+			&& _sparsedEntities[entity.id] < _packedEntities.length
+			&& _packedEntities[_sparsedEntities[entity.id]] == entity)
+		)
+			return false;
+
+		import std.algorithm : swap;
+		import std.range : back, popBack;
+		immutable last = _packedEntities.back;
+
+		// swap with the last element of packedEntities
+		swap(_components.back, _components[_sparsedEntities[entity.id]]);
+		swap(_packedEntities.back, _packedEntities[_sparsedEntities[entity.id]]);
+
+		// map the sparseEntities to the new value in packedEntities
+		swap(_sparsedEntities[last.id], _sparsedEntities[entity.id]);
+
+		// remove the last element
+		_components.popBack;
+		_packedEntities.popBack;
+
+		return true;
+	}
+
+private:
+	EntityType[] _sparsedEntities;
+	Entity!EntityType[] _packedEntities;
+	Component[] _components;
+}
+
+version(unittest)
+{
+	@Component struct Foo { int x; float y; }
+	@Component struct Bar { string str; }
+}
+
+@safe
+@("storage: Storage")
+unittest
+{
+	assertTrue(__traits(compiles, new Storage!(uint, Foo)));
+	assertTrue(__traits(compiles, new Storage!(uint, Bar)));
+	assertFalse(__traits(compiles, new Storage!(uint, InvalidComponent)));
+}
+
+@safe
+@("storage: Storage: add")
+unittest
+{
+	auto storage = new Storage!(uint, Foo);
+
+	assertTrue(storage.add(Entity!uint(0), Foo(3, 2)));
+	assertFalse(storage.add(Entity!uint(0, 4), Foo(3, 2)));
+	assertEquals(Entity!uint(0), storage._packedEntities[storage._sparsedEntities[0]]);
+	assertEquals(Entity!uint(0), storage._packedEntities[0]);
+}
+
+@safe
+@("storage: Storage: remove")
+unittest
+{
+	auto storage = new Storage!(ubyte, Bar);
+
+	storage.add(Entity!ubyte(0), Bar("bar"));
+	storage.add(Entity!ubyte(1), Bar("bar"));
+
+	assertFalse(storage.remove(Entity!ubyte(0, 5)));
+	assertFalse(storage.remove(Entity!ubyte(42)));
+	assertTrue(storage.remove(Entity!ubyte(0)));
+
+	assertEquals(1, storage._sparsedEntities[0]);
+	assertEquals(Entity!ubyte(1), storage._packedEntities[storage._sparsedEntities[1]]);
+	assertEquals(Entity!ubyte(1), storage._packedEntities[0]);
+}


### PR DESCRIPTION
Changes:
 * added an EntityManager class and Entity struct
 * added a Storage class and StorageInfo struct
 * added an EntityBuilder helper

The EntityManager takes an unsigned and integral type.
Entities are composed by an **id** and a **batch**.
```d
auto em = new EntityManager!uint(); // creates an EntityManager

auto e = em.gen(); // fabricates a new entity
em.discard(e); // discards the entity e
em.gen(); // recycles e with a new batch
```

Multiple entities can be generated with the EntityBuilder.
The entities are immediately generated with the `gen` method in the EntityManager.
However, instead of returning the generated entity, it allows multiple chained calls.
```d
auto em = new EntityBuilder!uint();

// generates 2 entities
em.entityBuilder()
  .gen()
  .gen();

// get() method can be used to retrieve all entities generated with the used EntityBuilder instance.
auto entities = em.entityBuilder()
  .gen()
  .gen()
  .get();
```

Storages will be used to store a component an the entities which contain one.
Components must be a **struct** and have the `@Component` UDA attached.
Storage class is package as it is meant to be used internally only.
Storage must have the **entity type** and the component**.
```d
@Component struct Foo {} // valid component

auto storage = new Storage!(uint, Foo); // creates a Storage of uint entity types and Foo components

storage.add(Entity!uint(0), Foo()); // adds a component to an entity
storage.remove(Entity!uint(0)); // removes the component associated with an entity
```

StorageInfo will be the bridge which connects the EntityManager to the Storage.