### PR TITLE
EntityManager and Storage connection

### DIFF
--- a/source/ecs/entity.d
+++ b/source/ecs/entity.d
@@ -437,6 +437,29 @@ public:
 		return storageInfoMap[componentId!Component].getStorage!(Component).get(entity);
 	}
 
+
+	/**
+	 * Fetch the component if associated to the entity, otherwise the component
+	 *     passed in the parameters is set and returned. If the entity is
+	 *     invalid null is returned instead.
+	 *
+	 * Params:
+	 *     entity = the entity to fetch the associated component.
+	 *     component = a valid component to set if there is none associated.
+	 *
+	 * Returns: the Component* associated or created if successful, null otherwise.
+	 */
+	Component* getOrSet(Component)(in Entity!T entity, in Component component = Component.init)
+	{
+		// Invalid action if the entity is not valid
+		if (!(entity.id < entities.length && entities[entity.id] == entity))
+			return null;
+		else if (componentId!Component !in storageInfoMap)
+			storageInfoMap[componentId!Component] = StorageInfo!(T)().__ctor!(Component)();
+
+		return storageInfoMap[componentId!Component].getStorage!(Component).getOrSet(entity, component);
+	}
+
 private:
 	/**
 	 * Creates a new entity with a new id. The entity's id follows the total
@@ -613,6 +636,21 @@ unittest
 	assertEquals(Foo(int.init, 10.0f), *em.get!Foo(e));
 
 	assertFalse(__traits(compiles, em.get!InvalidComponent(em.gen())));
+}
+
+@safe
+@("entity: EntityManager: getOrSet")
+unittest
+{
+	auto em = new EntityManager!size_t();
+
+	auto e = em.gen!(Foo)();
+	assertEquals(Foo.init, *em.getOrSet!Foo(e));
+	assertEquals(Foo.init, *em.getOrSet(e, Foo(2, 3)));
+	assertEquals(Bar("str"), *em.getOrSet(e, Bar("str")));
+
+	assertNull(em.getOrSet!Foo(Entity!size_t(0, 12)));
+	assertNull(em.getOrSet!Foo(Entity!size_t(3)));
 }
 
 @safe

--- a/source/ecs/entity.d
+++ b/source/ecs/entity.d
@@ -413,6 +413,30 @@ public:
 		return true;
 	}
 
+
+	/**
+	 * Fetch a component associated to an entity. If the entity is invalid, the
+	 *     Component wasn't associated with any entity or the entity does not
+	 *     have this Component associated to it a null is returned instead.
+	 *
+	 * Params:
+	 *     entity = the entity to get the associated Component.
+	 *     Component = a valid component type to retrieve.
+	 *
+	 * Returns: Component* with the associated component if sucessful, null otherwise
+	 */
+	Component* get(Component)(in Entity!T entity)
+	{
+		// Invalid action if the entity is not valid
+		if (!(entity.id < entities.length
+			&& entities[entity.id] == entity
+			&& componentId!Component in storageInfoMap)
+		)
+			return null;
+
+		return storageInfoMap[componentId!Component].getStorage!(Component).get(entity);
+	}
+
 private:
 	/**
 	 * Creates a new entity with a new id. The entity's id follows the total
@@ -571,6 +595,24 @@ unittest
 	assertFalse(__traits(compiles, em.gen(Foo(3,3), Bar(5,3), Foo.init)));
 	assertFalse(__traits(compiles, em.gen!(Foo, Bar, InvalidComponent)()));
 	assertFalse(__traits(compiles, em.gen!InvalidComponent()));
+}
+
+@safe
+@("entity: EntityManager: get")
+unittest
+{
+	auto em = new EntityManager!size_t();
+
+	auto e = em.gen!(Foo, Bar);
+
+	assertEquals(Foo.init, *em.get!Foo(e));
+	assertEquals(Bar.init, *em.get!Bar(e));
+	assertNull(em.get!ValidComponent(e));
+
+	em.get!Foo(e).y = 10.0f;
+	assertEquals(Foo(int.init, 10.0f), *em.get!Foo(e));
+
+	assertFalse(__traits(compiles, em.get!InvalidComponent(em.gen())));
 }
 
 @safe

--- a/source/ecs/entity.d
+++ b/source/ecs/entity.d
@@ -460,6 +460,23 @@ public:
 		return storageInfoMap[componentId!Component].getStorage!(Component).getOrSet(entity, component);
 	}
 
+
+	/**
+	 * Get the size of Component Storage. The size represents how many entities
+	 *     are associated to a component type.
+	 *
+	 * Params: Component = a Component type to search.
+	 *
+	 * Returns: the amount of entities/components within that Storage or 0 if it
+	 *     fails.
+	 */
+	size_t size(Component)() const
+	{
+		return componentId!Component in storageInfoMap
+			? storageInfoMap[componentId!Component].size()
+			: 0;
+	}
+
 private:
 	/**
 	 * Creates a new entity with a new id. The entity's id follows the total
@@ -716,4 +733,18 @@ unittest
 	assertFalse(__traits(compiles, em.set(em.gen(), Foo(4, 5), Bar("str"), Foo.init)));
 	assertFalse(__traits(compiles, em.set!(Foo, Bar, InvalidComponent)(em.gen())));
 	assertFalse(__traits(compiles, em.set!(InvalidComponent)(em.gen())));
+}
+
+@safe
+@("entity: EntityManager: size")
+unittest
+{
+	auto em = new EntityManager!size_t();
+
+	auto e = em.gen!Foo;
+	assertEquals(1, em.size!Foo());
+	assertEquals(0, em.size!Bar());
+
+	em.remove!Foo(e);
+	assertEquals(0, em.size!Foo());
 }

--- a/source/ecs/entity.d
+++ b/source/ecs/entity.d
@@ -414,6 +414,18 @@ public:
 	}
 
 
+	@safe
+	bool removeAll(Component)()
+	{
+		if (componentId!Component !in storageInfoMap)
+			return false;
+
+		storageInfoMap[componentId!Component].removeAll();
+
+		return true;
+	}
+
+
 	/**
 	 * Fetch a component associated to an entity. If the entity is invalid, the
 	 *     Component wasn't associated with any entity or the entity does not
@@ -712,6 +724,19 @@ unittest
 
 	// cannot call with invalid components
 	assertFalse(__traits(compiles, em.remove!InvalidComponent(e)));
+}
+
+@safe
+@("entity: EntityManager: removeAll")
+unittest
+{
+	auto em = new EntityManager!size_t();
+
+	foreach (i; 0..10) em.gen!(Foo, Bar);
+
+	assertEquals(10, em.size!Foo());
+	assertTrue(em.removeAll!Foo());
+	assertEquals(0, em.size!Foo());
 }
 
 @safe

--- a/source/ecs/entitybuilder.d
+++ b/source/ecs/entitybuilder.d
@@ -61,7 +61,7 @@ public:
 	}
 
 
-	@safe
+	@safe pure
 	auto gen()
 	{
 		entities ~= em.gen();
@@ -83,7 +83,7 @@ public:
 	}
 
 
-	@safe
+	@safe pure
 	auto get()
 	{
 		return entities;

--- a/source/ecs/entitybuilder.d
+++ b/source/ecs/entitybuilder.d
@@ -20,14 +20,28 @@ auto entityBuilder(EntityType)(EntityManager!EntityType em)
 @("entitybuilder: entityBuilder")
 unittest
 {
+	import ecs.storage;
 	EntityManager!uint em = new EntityManager!uint();
-	auto entitites = em.entityBuilder
+	auto entities = em.entityBuilder
 		.gen()
 		.gen()
 		.gen()
 		.get();
 
-	assertEquals([Entity!uint(0), Entity!uint(1), Entity!uint(2)], entitites);
+	assertEquals([Entity!uint(0), Entity!uint(1), Entity!uint(2)], entities);
+
+	entities = em.entityBuilder
+		.gen!(Foo)()
+		.gen()
+		.gen(Bar("str"))
+		.gen!(Foo, ValidComponent)()
+		.get();
+
+	assertEquals([Entity!uint(3), Entity!uint(4), Entity!uint(5), Entity!uint(6)], entities);
+
+	assertFalse(__traits(compiles, em.entityBuilder.gen!(Foo, Bar, Foo)()));
+	assertFalse(__traits(compiles, em.entityBuilder.gen(Foo.init, Bar.init, Foo(3, 4))));
+	assertFalse(__traits(compiles, em.entityBuilder.gen!(Foo, Bar, InvalidComponent)()));
 }
 
 
@@ -55,8 +69,22 @@ public:
 	}
 
 
+	auto gen(ComponentRange ...)()
+	{
+		entities ~= em.gen!(ComponentRange)();
+		return this;
+	}
+
+
+	auto gen(ComponentRange ...)(ComponentRange components)
+	{
+		entities ~= em.gen(components);
+		return this;
+	}
+
+
 	@safe
-	auto get() const
+	auto get()
 	{
 		return entities;
 	}

--- a/source/ecs/storage.d
+++ b/source/ecs/storage.d
@@ -179,6 +179,17 @@ package class Storage(EntityType, Component)
 	}
 
 
+	/**
+	 * Disaasociates an entity from it's component. If the entity is storage
+	 *     invalid false is returned and the operation is halted. Both the
+	 *     component and the entity get swapped with the last elements from it's
+	 *     packed arrays and then removed. The sparse array is then mapped to
+	 *     the new location of the swapped entity.
+	 *
+	 * Params: entity = the entity to disassociate from it's component.
+	 *
+	 * Returns: true if successfuly removed, false otherwise;
+	 */
 	@safe
 	bool remove(in Entity!EntityType entity)
 	{

--- a/source/ecs/storage.d
+++ b/source/ecs/storage.d
@@ -100,7 +100,7 @@ public:
 			: null;
 	}
 
-	bool delegate(Entity!EntityType entity) remove;
+	bool delegate(Entity!EntityType entity) @safe remove;
 
 private:
 	TypeInfo cid;

--- a/source/ecs/storage.d
+++ b/source/ecs/storage.d
@@ -91,6 +91,7 @@ public:
 
 		(() @trusted => this.storage = cast(void*) storage)();
 		this.remove = &storage.remove;
+		this.removeAll = &storage.removeAll;
 	}
 
 	Storage!(EntityType, Component) getStorage(Component)()
@@ -101,6 +102,7 @@ public:
 	}
 
 	bool delegate(Entity!EntityType entity) @safe remove;
+	void delegate() @safe removeAll;
 
 private:
 	TypeInfo cid;
@@ -223,6 +225,16 @@ package class Storage(EntityType, Component)
 		_packedEntities.popBack;
 
 		return true;
+	}
+
+
+	///
+	@safe
+	void removeAll()
+	{
+		_sparsedEntities = [];
+		_packedEntities = [];
+		_components = [];
 	}
 
 

--- a/source/ecs/storage.d
+++ b/source/ecs/storage.d
@@ -40,7 +40,7 @@ version(unittest)
 }
 
 ///
-@safe
+@safe pure
 @("storage: isComponent")
 unittest
 {
@@ -61,7 +61,7 @@ template componentId(Component)
 }
 
 ///
-@safe
+@safe pure
 @("storage: componentId")
 unittest
 {
@@ -95,23 +95,24 @@ public:
 		this.size = &storage.size;
 	}
 
+	///
 	Storage!(EntityType, Component) getStorage(Component)()
 	{
 		return cid is componentId!Component
-			? (() @trusted => cast(Storage!(EntityType, Component)) storage)() // safe cast
+			? (() @trusted => cast(Storage!(EntityType, Component)) storage)() // safe pure cast
 			: null;
 	}
 
-	bool delegate(Entity!EntityType entity) @safe remove;
-	void delegate() @safe removeAll;
-	size_t delegate() @safe size;
+	bool delegate(Entity!EntityType entity) @safe pure remove;
+	void delegate() @safe pure removeAll;
+	size_t delegate() @safe pure size;
 
 private:
 	TypeInfo cid;
 	void* storage;
 }
 
-@safe
+@safe pure
 @("storage: StorageInfo")
 unittest
 {
@@ -122,7 +123,7 @@ unittest
 	assertFalse(__traits(compiles, sinfo.getStorage!InvalidComponent));
 }
 
-@safe
+@safe pure
 @("storage: StorageInfo")
 unittest
 {
@@ -163,7 +164,7 @@ package class Storage(EntityType, Component)
 	 *
 	 * Returns: true if the component was set, false otherwise.
 	 */
-	@safe
+	@safe pure
 	bool set(in Entity!EntityType entity, in Component component)
 	{
 		if (entity.id < _sparsedEntities.length
@@ -202,7 +203,7 @@ package class Storage(EntityType, Component)
 	 *
 	 * Returns: true if successfuly removed, false otherwise;
 	 */
-	@safe
+	@safe pure
 	bool remove(in Entity!EntityType entity)
 	{
 		if (!(entity.id < _sparsedEntities.length
@@ -231,7 +232,7 @@ package class Storage(EntityType, Component)
 
 
 	///
-	@safe
+	@safe pure
 	void removeAll()
 	{
 		_sparsedEntities = [];
@@ -248,7 +249,7 @@ package class Storage(EntityType, Component)
 	 *
 	 * Returns: a pointer to the component if search was successful, null otherwise.
 	 */
-	@safe
+	@safe pure
 	Component* get(in Entity!EntityType entity)
 	{
 		// return null if the entity is invalid
@@ -273,7 +274,7 @@ package class Storage(EntityType, Component)
 	 *
 	 * Returns: the Component* associated or created if successful, null otherwise.
 	 */
-	@safe
+	@safe pure
 	Component* getOrSet(in Entity!EntityType entity, in Component component)
 	{
 		if (entity.id < _sparsedEntities.length
@@ -297,13 +298,14 @@ package class Storage(EntityType, Component)
 	}
 
 
-	@safe
+	@safe pure
 	size_t size() const
 	{
 		return _components.length;
 	}
 
 private:
+	@safe pure
 	Component* _set(in Entity!EntityType entity, in Component component)
 	{
 		_packedEntities ~= entity; // set entity
@@ -311,7 +313,7 @@ private:
 
 		// map to the correct entity from the packedEntities from sparsedEntities
 		if (entity.id >= _sparsedEntities.length) _sparsedEntities.length = entity.id + 1;
-		_sparsedEntities[entity.id] = cast(EntityType)(_packedEntities.length - 1); // safe cast
+		_sparsedEntities[entity.id] = cast(EntityType)(_packedEntities.length - 1); // safe pure cast
 
 		return &_components[_sparsedEntities[entity.id]];
 	}
@@ -323,11 +325,11 @@ private:
 
 version(unittest)
 {
-	@Component struct Foo { int x; float y = 0.0f; }
+	@Component struct Foo { int x, y; }
 	@Component struct Bar { string str; }
 }
 
-@safe
+@safe pure
 @("storage: Storage")
 unittest
 {
@@ -336,7 +338,7 @@ unittest
 	assertFalse(__traits(compiles, new Storage!(uint, InvalidComponent)));
 }
 
-@safe
+@safe pure
 @("storage: Storage: get")
 unittest
 {
@@ -352,7 +354,7 @@ unittest
 	assertEquals(Foo(3, 3), *storage.get(Entity!size_t(0)));
 }
 
-@safe
+@safe pure
 @("storage: Storage: getOrSet")
 unittest
 {
@@ -363,7 +365,7 @@ unittest
 	assertNull(storage.getOrSet(Entity!size_t(0, 54), Foo(2, 3)));
 }
 
-@safe
+@safe pure
 @("storage: Storage: remove")
 unittest
 {
@@ -381,7 +383,7 @@ unittest
 	assertEquals(Entity!ubyte(1), storage._packedEntities[0]);
 }
 
-@safe
+@safe pure
 @("storage: Storage: set")
 unittest
 {

--- a/source/ecs/storage.d
+++ b/source/ecs/storage.d
@@ -206,6 +206,28 @@ package class Storage(EntityType, Component)
 		return true;
 	}
 
+
+	/**
+	 * Fetches the component of entity if exists. If the entity is not storage
+	 *     valid it returns null.
+	 *
+	 * Params: entity = the entity used to search for the component.
+	 *
+	 * Returns: a pointer to the component if search was successful, null otherwise.
+	 */
+	@safe
+	Component* get(in Entity!EntityType entity)
+	{
+		// return null if the entity is invalid
+		if (!(entity.id < _sparsedEntities.length
+			&& _sparsedEntities[entity.id] < _packedEntities.length
+			&& _packedEntities[_sparsedEntities[entity.id]] == entity)
+		)
+			return null;
+
+		return &_components[_sparsedEntities[entity.id]];
+	}
+
 private:
 	EntityType[] _sparsedEntities;
 	Entity!EntityType[] _packedEntities;
@@ -225,6 +247,22 @@ unittest
 	assertTrue(__traits(compiles, new Storage!(uint, Foo)));
 	assertTrue(__traits(compiles, new Storage!(uint, Bar)));
 	assertFalse(__traits(compiles, new Storage!(uint, InvalidComponent)));
+}
+
+@safe
+@("storage: Storage: get")
+unittest
+{
+	auto storage = new Storage!(size_t, Foo);
+
+	storage.set(Entity!size_t(0), Foo(3, 3));
+
+	assertNotNull(storage.get(Entity!size_t(0)));
+
+	assertNull(storage.get(Entity!size_t(0, 54)));
+	assertNull(storage.get(Entity!size_t(21)));
+
+	assertEquals(Foo(3, 3), *storage.get(Entity!size_t(0)));
 }
 
 @safe

--- a/source/ecs/storage.d
+++ b/source/ecs/storage.d
@@ -92,6 +92,7 @@ public:
 		(() @trusted => this.storage = cast(void*) storage)();
 		this.remove = &storage.remove;
 		this.removeAll = &storage.removeAll;
+		this.size = &storage.size;
 	}
 
 	Storage!(EntityType, Component) getStorage(Component)()
@@ -103,6 +104,7 @@ public:
 
 	bool delegate(Entity!EntityType entity) @safe remove;
 	void delegate() @safe removeAll;
+	size_t delegate() @safe size;
 
 private:
 	TypeInfo cid;
@@ -292,6 +294,13 @@ package class Storage(EntityType, Component)
 		}
 
 		return &_components[_sparsedEntities[entity.id]];
+	}
+
+
+	@safe
+	size_t size() const
+	{
+		return _components.length;
 	}
 
 private:


### PR DESCRIPTION
Changes:
 * fixed methods not being `pure`
 * refactored `add` method to `set`
 * refactored the constraint of a component to only accept mutable fields
 * added the Assoc Array of StorageInfo[TypeInfo] searchable by the Component type to have access to the Storage through the EntityManager
 * added the following methods to manipulate entities and components:
   * `get` - fetches a component from an entity, returns a pointer to the component or null if it fails
   * `set` - associates an entity with a component, returns true if successful or false if it fails
   * `remove` - removes a component from an entity, returns true if successful or false if it fails
   * `removeAll` - removes all components from an entity or storage, returns true if successful or false if it fails
   * `gen` - now an entity can be generated with components on the fly, returns the newly generated entity
   * `getOrSet` - set the component if the entity is no associated with one and/or returns it
   * `size` - gets the the amount of components/entities within a component storage
 
A component can be associated to an entity the following ways:
```d
@Component struct Foo {}
@Component struct Bar {}
auto em = new EntityManager!size_t();

// with set
em.set!Foo(em.gen());
em.set(Foo, Bar)(em.gen());
em.set(em.gen(), Foo());
em.set(em.gen(), Foo(), Bar());

// with gen
em.gen!Foo;
em.gen!(Foo, Bar);
em.gen(Foo());
em.gen(Foo(), Bar());

// with getOrSet
em.getOrSet!Foo(em.gen());
em.getOrSet!Foo(em.gen(), Foo());

// gen was also updated to work with EntityBuilder
em.entityBuilder
    .gen!(Foo)
    .gen!(Foo, Bar)
    .gen(Foo())
    .gen(Foo(), Bar());
```

Components can be fetched the following ways:
```d
@Component struct Foo { int x, y; }
auto em = new EntityManager!size_t();

// with get
Foo* foo = em.get!Foo(em.gen!Foo);

// with getOrSet
Foo* foo = em.getOrSet!Foo(e);
Foo* foo = em.getOrSet(e, Foo(2, 3));
```

Components can be removed using:
```d
@Component struct Foo {}
@Component struct Bar {}
@Component struct Foobar{}
auto em = new EntityManager!size_t();

em.remove!Foo(em.gen!Foo); // removes Foo, returns true
em.remove!Bar(em.gen!Foo); // does not remove any, returns false
em.removeAll(em.gen!(Foo, Bar)); // removes all from the newly gen entity, returns true
em.removeAll(em.entityNull); // invalid entity, returns false
em.removeAll!Foo(); // removes all components and entities in Foo Storage, returns true
em.removeAll!Foobar(); // there is no Foobar Storage, returns false
```