### PR TITLE
Fix entity type

### DIFF
--- a/source/ecs/entity.d
+++ b/source/ecs/entity.d
@@ -437,6 +437,19 @@ public:
 			: 0;
 	}
 
+
+	/**
+	 * Helper struct to perform multiple actions sequences.
+	 *
+	 * Returns: an EntityBuilder.
+	 */
+	@safe pure
+	auto entityBuilder()
+	{
+		import ecs.entitybuilder : EntityBuilder;
+		return EntityBuilder(this);
+	}
+
 private:
 	/**
 	 * Creates a new entity with a new id. The entity's id follows the total

--- a/source/ecs/entity.d
+++ b/source/ecs/entity.d
@@ -676,6 +676,8 @@ unittest
 	assertEquals(10, em.size!Foo());
 	assertTrue(em.removeAll!Foo());
 	assertEquals(0, em.size!Foo());
+
+	assertFalse(em.removeAll!ValidComponent);
 }
 
 @safe pure
@@ -692,6 +694,10 @@ unittest
 
 	assertTrue(em.set(em.gen(), Foo(4, 5), Bar("str")));
 	assertTrue(em.set!(Foo, Bar, ValidComponent)(em.gen()));
+
+	assertFalse(em.set!Foo(Entity(45)));
+	assertFalse(em.set!(Foo, Bar)(Entity(45)));
+	assertFalse(em.set(Entity(45), Foo.init, Bar.init));
 
 	assertFalse(__traits(compiles, em.set!(Foo, Bar, ValidComponent, Bar)(em.gen())));
 	assertFalse(__traits(compiles, em.set(em.gen(), Foo(4, 5), Bar("str"), Foo.init)));

--- a/source/ecs/entitybuilder.d
+++ b/source/ecs/entitybuilder.d
@@ -9,52 +9,11 @@ version(unittest) import aurorafw.unit.assertion;
  * Helper struct to perform multiple actions sequences.
  *
  * Params: em = an entity manager to update.
- *
- * Returns: an EntityBuilder!EntityType.
- */
-auto entityBuilder(EntityManager em)
-{
-	return EntityBuilder(em);
-}
-
-@("entitybuilder: entityBuilder")
-unittest
-{
-	import ecs.storage;
-	EntityManager em = new EntityManager();
-	auto entities = em.entityBuilder
-		.gen()
-		.gen()
-		.gen()
-		.get();
-
-	assertEquals([Entity(0), Entity(1), Entity(2)], entities);
-
-	entities = em.entityBuilder
-		.gen!(Foo)()
-		.gen()
-		.gen(Bar("str"))
-		.gen!(Foo, ValidComponent)()
-		.get();
-
-	assertEquals([Entity(3), Entity(4), Entity(5), Entity(6)], entities);
-
-	assertFalse(__traits(compiles, em.entityBuilder.gen!(Foo, Bar, Foo)()));
-	assertFalse(__traits(compiles, em.entityBuilder.gen(Foo.init, Bar.init, Foo(3, 4))));
-	assertFalse(__traits(compiles, em.entityBuilder.gen!(Foo, Bar, InvalidComponent)()));
-}
-
-
-/**
- * Helper struct to perform multiple actions sequences.
- *
- * Params:
- *     EntityType = a valid entity type.
- *     em = an entity manager to update.
  */
 struct EntityBuilder
 {
 public:
+	@safe pure
 	this(EntityManager em)
 	{
 		this.em = em;
@@ -93,4 +52,33 @@ public:
 private:
 	Entity[] entities;
 	EntityManager em;
+}
+
+
+@safe pure
+@("entitybuilder: entityBuilder")
+unittest
+{
+	import ecs.storage;
+	EntityManager em = new EntityManager();
+	auto entities = em.entityBuilder
+		.gen()
+		.gen()
+		.gen()
+		.get();
+
+	assertEquals([Entity(0), Entity(1), Entity(2)], entities);
+
+	entities = em.entityBuilder
+		.gen!(Foo)()
+		.gen()
+		.gen(Bar("str"))
+		.gen!(Foo, ValidComponent)()
+		.get();
+
+	assertEquals([Entity(3), Entity(4), Entity(5), Entity(6)], entities);
+
+	assertFalse(__traits(compiles, em.entityBuilder.gen!(Foo, Bar, Foo)()));
+	assertFalse(__traits(compiles, em.entityBuilder.gen(Foo.init, Bar.init, Foo(3, 4))));
+	assertFalse(__traits(compiles, em.entityBuilder.gen!(Foo, Bar, InvalidComponent)()));
 }

--- a/source/ecs/entitybuilder.d
+++ b/source/ecs/entitybuilder.d
@@ -12,23 +12,23 @@ version(unittest) import aurorafw.unit.assertion;
  *
  * Returns: an EntityBuilder!EntityType.
  */
-auto entityBuilder(EntityType)(EntityManager!EntityType em)
+auto entityBuilder(EntityManager em)
 {
-	return EntityBuilder!EntityType(em);
+	return EntityBuilder(em);
 }
 
 @("entitybuilder: entityBuilder")
 unittest
 {
 	import ecs.storage;
-	EntityManager!uint em = new EntityManager!uint();
+	EntityManager em = new EntityManager();
 	auto entities = em.entityBuilder
 		.gen()
 		.gen()
 		.gen()
 		.get();
 
-	assertEquals([Entity!uint(0), Entity!uint(1), Entity!uint(2)], entities);
+	assertEquals([Entity(0), Entity(1), Entity(2)], entities);
 
 	entities = em.entityBuilder
 		.gen!(Foo)()
@@ -37,7 +37,7 @@ unittest
 		.gen!(Foo, ValidComponent)()
 		.get();
 
-	assertEquals([Entity!uint(3), Entity!uint(4), Entity!uint(5), Entity!uint(6)], entities);
+	assertEquals([Entity(3), Entity(4), Entity(5), Entity(6)], entities);
 
 	assertFalse(__traits(compiles, em.entityBuilder.gen!(Foo, Bar, Foo)()));
 	assertFalse(__traits(compiles, em.entityBuilder.gen(Foo.init, Bar.init, Foo(3, 4))));
@@ -52,10 +52,10 @@ unittest
  *     EntityType = a valid entity type.
  *     em = an entity manager to update.
  */
-struct EntityBuilder(EntityType)
+struct EntityBuilder
 {
 public:
-	this(EntityManager!EntityType em)
+	this(EntityManager em)
 	{
 		this.em = em;
 	}
@@ -91,6 +91,6 @@ public:
 
 
 private:
-	Entity!(EntityType)[] entities;
-	EntityManager!EntityType em;
+	Entity[] entities;
+	EntityManager em;
 }


### PR DESCRIPTION
Changes:
 * EntityType removed from objects as a template parameter. This is now a custom type declared directly in the Entity struct.
 * Improved code coverage
 * Moved entityBuilder to EntityManager
 * Removed trait `isEntityType`
 * Removed mixin template `genEntityMask`

EntityManager and Entity are now initialized the following way:
```d
auto em = new EntityManager();
auto e = Entity(0, 0);
```

Entity
 * Custom type of size_t formed by the junction of `id` with `batch`
 * Defines the maximum values for ids and batches depending on the pointer size
 * Defines other constants which were generated before by the `genEntityMask` mixin template