### PR TITLE
Optimize component access

### DIFF
--- a/source/ecs/entitybuilder.d
+++ b/source/ecs/entitybuilder.d
@@ -73,12 +73,12 @@ unittest
 		.gen!(Foo)()
 		.gen()
 		.gen(Bar("str"))
-		.gen!(Foo, ValidComponent)()
+		.gen!(Foo, int)()
 		.get();
 
 	assertEquals([Entity(3), Entity(4), Entity(5), Entity(6)], entities);
 
 	assertFalse(__traits(compiles, em.entityBuilder.gen!(Foo, Bar, Foo)()));
 	assertFalse(__traits(compiles, em.entityBuilder.gen(Foo.init, Bar.init, Foo(3, 4))));
-	assertFalse(__traits(compiles, em.entityBuilder.gen!(Foo, Bar, InvalidComponent)()));
+	assertFalse(__traits(compiles, em.entityBuilder.gen!(Foo, Bar, immutable(int))()));
 }


### PR DESCRIPTION
Changes:
 * some safety checks are now evaluated only in debug mode
 * increased the number of types for components
 * a component does not have to contain the @Component UDA anymore
 * StorageInfo data is now stored in an array
 * components now have an unique id number generated by type
 * changes in some function return types
 * addition of some functions to help component manipulation
   * `has`: checks if an entity exists
   * `removeIfHas`: removes a component if an entity is associated with it
   * `discardIfHas`: disards an entity if exists
   * `_assure`: assures the availability of a storage, creates one if no storage of a component exists and returns it

Everything can be a component unless it is a `class, union, any function, not mutable type or struct fields`:
```d
auto em = new EntityManager();
auto e = em.gen(12, "this is also a component", [1, 2]);

// works the same way as before
assert(12 == em.get!int(e));
```

Now an AssertError will be thrown when passing invalid entities in debug mode:
```d
auto em = new EntityManager();

assertThrown!AssertError(em.get!int(Entity(0)); // invalid entity
assertThrown!AssertError(em.get!int(gen()); // invalid entity in Storage!int
```

Every time a Component is used, an assurance is made to guarantee the Storage is available:
```d
auto em = new EntityManager();

assert(0, em.size!int(em.gen())); // Storage!int is created with no entities
```

Changes to return types:
 * `remove` does not return anything as we can assume the component will always be removed successfully
 * `removeIfHas` does not return anything (subject to change)
 * `removeAll` does not return anything, and uses `removeIfHas` for each storage
 * `discard` does not return anything as we can assume the entity will always be successfully discarded
 * `discardIfHas` does not return anything (subject to change)
 * `set(C)` always returns a pointer to the component as we can assume there will always exists the component
 * `set(C ...)` always returns a tuple with pointer to the components

These changes were based on the fact that the user is **not** supposed to access the `EntityManager` using random entities or store entities for latter usage. Every entity handed to the user is a copy of what's stored and **should not be kept***. From now on, this lib will not support such usage and the result of these actions will lead to ***undefined behavior***!