### PR TITLE
Add queries

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -6,7 +6,16 @@
 	"targetPath": "bin",
 	"license": "MIT",
 	"targetType": "library",
-	"dependencies": {
-		"aurorafw:unit": "~>0.0.1-alpha.4"
-	}
+	"configurations": [
+        {
+            "name": "default"
+        },
+        {
+            "name": "unittest",
+            "targetType": "autodetect",
+            "dependencies": {
+                "aurorafw:unit": "0.0.1-alpha.4"
+			}
+        }
+    ]
 }

--- a/examples/benchmarks/dub.json
+++ b/examples/benchmarks/dub.json
@@ -1,0 +1,10 @@
+{
+    "name": "benchmarks",
+    "targetType": "none",
+    "dependencies": {
+        ":query": "*"
+    },
+    "subPackages": [
+        "query"
+    ]
+}

--- a/examples/benchmarks/query/dub.json
+++ b/examples/benchmarks/query/dub.json
@@ -1,0 +1,11 @@
+{
+    "name": "query",
+    "targetType": "executable",
+    "targetPath": "../../.out/bin",
+    "sourcePaths": ["source"],
+    "importPaths": ["source"],
+    "dependencies": {
+        "valhala_ecs": {"path": "../../../"}
+    },
+    "dflags": ["-release", "-O", "-inline", "-boundscheck=off"]
+}

--- a/examples/benchmarks/query/dub.selections.json
+++ b/examples/benchmarks/query/dub.selections.json
@@ -1,0 +1,9 @@
+{
+	"fileVersion": 1,
+	"versions": {
+		"aurorafw": "0.0.1-alpha.4",
+		"emsi_containers": "0.8.0",
+		"stdx-allocator": "2.77.5",
+		"valhala_ecs": {"path":"../../../"}
+	}
+}

--- a/examples/benchmarks/query/source/app.d
+++ b/examples/benchmarks/query/source/app.d
@@ -1,0 +1,83 @@
+module app;
+
+import ecs.entity;
+import ecs.storage;
+import ecs.query;
+import ecs.queryfilter;
+
+import std.algorithm : each;
+import std.datetime.stopwatch : benchmark;
+import std.range : iota;
+import std.stdio;
+import std.typecons : Tuple;
+
+struct PositionComponent
+{
+	loat x = 0.0f;
+	loat y = 0.0f;
+}
+
+struct DirectionComponent
+{
+	float x = 0.0f;
+	float y = 0.0f;
+}
+
+struct ComflabulationComponent
+{
+	float thingy = 0.1f;
+	int dingy;
+	bool mingy;
+	string stringy = "";
+}
+
+void main()
+{
+	auto em = new EntityManager();
+	enum Loops = 100_000;
+
+	3_000.iota.each!(i => em.gen!(PositionComponent)());
+	3_000.iota.each!(i => em.gen!(PositionComponent, DirectionComponent)());
+	1_000.iota.each!(i => em.gen!(ComflabulationComponent, DirectionComponent)());
+	1_000.iota.each!(i => em.gen!(ComflabulationComponent, DirectionComponent, PositionComponent)());
+	2_000.iota.each!(i => em.gen!(DirectionComponent, ComflabulationComponent)());
+
+	benchmark!({
+		foreach (pos, dir; em.query!(Tuple!(PositionComponent, DirectionComponent)))
+		{
+			pos.x += dir.x * 0.15;
+			pos.y += dir.y * 0.15;
+		}
+	},{
+		foreach (com; em.query!(ComflabulationComponent))
+		{
+			com.thingy *= 1.0000001f;
+			com.dingy++;
+			com.mingy = !com.mingy;
+		}
+	},{
+		foreach (pos, dir, com; em.query!(Tuple!(PositionComponent, DirectionComponent, ComflabulationComponent)))
+		{
+			if ((com.mingy = !com.mingy) == false)
+			{
+				com.dingy++;
+
+				pos.x += dir.x * com.thingy;
+				pos.y += dir.y * com.thingy;
+			}
+
+			com.thingy *= 1.0000001f;
+		}
+	},{
+		foreach (pos, i; em.query!(Tuple!(PositionComponent, int)))
+		{
+			pos.x++;
+		}
+	},{
+		foreach (pos, dir; em.query!(Tuple!(PositionComponent, DirectionComponent), With!(ComflabulationComponent)))
+		{
+			pos.x += dir.x * 0.15;
+			pos.y += dir.y * 0.15;
+		}
+	})(Loops).each!(dur => writeln(dur/Loops));
+}

--- a/examples/dub.json
+++ b/examples/dub.json
@@ -1,0 +1,10 @@
+{
+    "name": "examples",
+    "targetType": "none",
+    "dependencies": {
+        ":benchmarks": "*"
+    },
+    "subPackages": [
+        "benchamrks"
+    ]
+}

--- a/source/ecs/package.d
+++ b/source/ecs/package.d
@@ -1,0 +1,9 @@
+module ecs;
+
+public:
+	import ecs.entity;
+	import ecs.entitybuilder;
+	import ecs.query;
+	import ecs.queryfilter;
+	import ecs.queryworld;
+	import ecs.storage;

--- a/source/ecs/query.d
+++ b/source/ecs/query.d
@@ -1,0 +1,310 @@
+module ecs.query;
+
+import ecs.entity;
+import ecs.storage;
+import ecs.queryfilter;
+import ecs.queryworld;
+
+import std.format : format;
+import std.meta : AliasSeq, allSatisfy, anySatisfy, Filter, NoDuplicates;
+import std.range : iota;
+import std.traits : isInstanceOf, staticMap, TemplateArgsOf;
+import std.typecons : Tuple, tuple;
+
+version(unittest) import aurorafw.unit.assertion;
+
+struct Query(Output)
+{
+package:
+	this(QueryWorld!Output range)
+	{
+		this.range = range;
+	}
+
+public:
+	void popFront()
+	{
+		range.popFront();
+	}
+
+	@property
+	bool empty()
+	{
+		return range.empty;
+	}
+
+	@property
+	auto front()
+	{
+		return range.front;
+	}
+
+private:
+	QueryWorld!Output range;
+}
+
+@safe pure
+@("query: Entity")
+unittest
+{
+	import std.algorithm : each;
+
+	auto em = new EntityManager();
+	11.iota.each!(i => em.gen());
+
+	em.discard(Entity(2));
+	em.discard(Entity(3));
+	em.discard(Entity(5));
+	em.discard(Entity(6));
+	em.discard(Entity(7));
+	em.discard(Entity(9));
+	em.discard(Entity(10));
+
+	assertRangeEquals([Entity(0),Entity(1),Entity(4),Entity(8)], em.query!Entity);
+	assertRangeEquals(em.query!(Tuple!Entity), em.query!Entity);
+}
+
+@safe pure
+@("query: Component")
+unittest
+{
+	import std.algorithm : map;
+
+	auto em = new EntityManager();
+	em.entityBuilder()
+		.gen(Foo(2, 4), Bar.init, 4)
+		.gen!(Foo)
+		.gen!(Foo)
+		.gen!(Foo, Bar)
+		.gen!(Foo, Bar)
+		.gen!(Foo, Bar)
+		.gen!(Bar, int)
+		.gen!(Bar, int)
+		.gen!(Foo, Bar, int)
+		.gen!(Foo, Bar, int);
+
+	assertEquals(5, em.query!int.range.entities.length);
+	assertRangeEquals([4,0,0,0,0], em.query!int.map!"*a");
+	assertRangeEquals(em.query!(Tuple!int), em.query!int);
+}
+
+@safe pure
+@("query: OutputTuple")
+unittest
+{
+	import std.algorithm : map;
+
+	auto em = new EntityManager();
+	em.entityBuilder()
+		.gen(Foo(2, 4), Bar.init, 4)
+		.gen!(Foo)
+		.gen!(Foo)
+		.gen!(Foo, Bar)
+		.gen!(Foo, Bar)
+		.gen!(Foo, Bar)
+		.gen!(Bar, int)
+		.gen!(Bar, int)
+		.gen!(Foo, Bar, int)
+		.gen!(Foo, Bar, int);
+
+	auto range = [
+		tuple(4,Bar.init),
+		tuple(0,Bar.init),
+		tuple(0,Bar.init),
+		tuple(0,Bar.init),
+		tuple(0,Bar.init)
+	];
+
+	assertEquals(5, em.query!(Tuple!(int, Bar)).range.entities.length);
+	assertRangeEquals(range, em.query!(Tuple!(int, Bar)).map!"tuple(*a[0], *a[1])");
+
+	assertFalse(__traits(compiles, em.query!(Tuple!(Entity,Entity))));
+	assertFalse(__traits(compiles, em.query!(Tuple!(int,Entity))));
+
+	assertTrue(__traits(compiles, em.query!(Tuple!(int,int))));
+	assertTrue(__traits(compiles, em.query!(Tuple!(Entity,int,int))));
+}
+
+
+struct Query(Output, Filter)
+{
+package:
+	this(QueryWorld!Output range, QueryFilter!Filter filter)
+	{
+		this.range = range;
+		this.filter = filter;
+		_prime();
+	}
+
+public:
+	void popFront()
+	{
+		do {
+			range.popFront();
+		} while (!empty && !_validate());
+	}
+
+	@property
+	bool empty()
+	{
+		return range.empty;
+	}
+
+	@property
+	auto front()
+	{
+		return range.front;
+	}
+
+private:
+	void _prime()
+	{
+		while (!empty && !_validate())
+			popFront();
+	}
+
+	bool _validate()
+	{
+		return filter.validate(range.entities[0]);
+	}
+
+	QueryWorld!Output range;
+	QueryFilter!Filter filter;
+}
+
+@safe pure
+@("query: Entity + Filter")
+unittest
+{
+	auto em = new EntityManager();
+	em.entityBuilder()
+		.gen(Foo(2, 4), Bar.init, 4)
+		.gen!(Foo)
+		.gen!(Foo)
+		.gen!(Foo, Bar)
+		.gen!(Foo, Bar)
+		.gen!(Foo, Bar)
+		.gen!(Bar, int)
+		.gen!(Bar, int)
+		.gen!(Foo, Bar, int)
+		.gen!(Foo, Bar, int);
+
+	auto range = [Entity(0),Entity(6),Entity(7),Entity(8),Entity(9)];
+	assertEquals(5, em.query!(Entity, With!int).range.entities.length);
+	assertRangeEquals(range, em.query!(Entity, With!int)());
+
+	range = [Entity(0),Entity(8),Entity(9)];
+	assertEquals(5, em.query!(Entity, With!(int,Foo,Bar)).range.entities.length);
+	assertRangeEquals(range, em.query!(Entity, With!(int,Foo,Bar)));
+}
+
+@safe pure
+@("query: Component + Filter")
+unittest
+{
+	import std.algorithm : map;
+
+	auto em = new EntityManager();
+	em.entityBuilder()
+		.gen(Foo(2, 4), Bar.init, 4)
+		.gen!(Foo)
+		.gen!(Foo)
+		.gen!(Foo, Bar)
+		.gen!(Foo, Bar)
+		.gen!(Foo, Bar)
+		.gen!(Bar, int)
+		.gen!(Bar, int)
+		.gen!(Foo, Bar, int)
+		.gen!(Foo, Bar, int);
+
+	auto range = [
+		tuple(Entity(0), 4),
+		tuple(Entity(6), 0),
+		tuple(Entity(7), 0),
+		tuple(Entity(8), 0),
+		tuple(Entity(9), 0)
+	];
+
+	assertEquals(5, em.query!(Tuple!(Entity, int), With!Bar).range.entities.length);
+	assertRangeEquals(range, em.query!(Tuple!(Entity, int), With!Bar).map!"tuple(a[0],*a[1])");
+
+	range = [
+		tuple(Entity(0), 4),
+		tuple(Entity(8), 0),
+		tuple(Entity(9), 0)
+	];
+
+	assertEquals(5, em.query!(Tuple!(Entity, int), With!(Foo,Bar)).range.entities.length);
+	assertRangeEquals(range, em.query!(Tuple!(Entity, int), With!(Foo,Bar)).map!"tuple(a[0],*a[1])");
+}
+
+@safe pure
+@("query: OutputTuple + Filter")
+unittest
+{
+	import std.algorithm : map;
+
+	auto em = new EntityManager();
+	em.entityBuilder()
+		.gen(Foo(2, 4), Bar.init, 4)
+		.gen!(Foo)
+		.gen!(Foo)
+		.gen!(Foo, Bar)
+		.gen!(Foo, Bar)
+		.gen!(Foo, Bar)
+		.gen!(Bar, int)
+		.gen!(Bar, int)
+		.gen!(Foo, Bar, int)
+		.gen!(Foo, Bar, int);
+
+	auto range = [4,0,0,0,0];
+	assertEquals(5, em.query!(int, With!Bar).range.entities.length);
+	assertRangeEquals(range, em.query!(int, With!Bar).map!"*a");
+
+	range = [4,0,0];
+	assertEquals(5, em.query!(int, With!(Foo,Bar)).range.entities.length);
+	assertRangeEquals(range, em.query!(int, With!(Foo,Bar)).map!"*a");
+}
+
+@safe pure
+@("query: OutputTuple + FilterTuple")
+unittest
+{
+	import std.algorithm : map;
+
+	auto em = new EntityManager();
+	em.entityBuilder()
+		.gen(Foo(2, 4), Bar.init, 4)
+		.gen!(Foo)
+		.gen!(Foo)
+		.gen!(Foo, Bar)
+		.gen!(Foo, Bar)
+		.gen!(Foo, Bar)
+		.gen!(Bar, int)
+		.gen!(Bar, int)
+		.gen!(Foo, Bar, int)
+		.gen!(Foo, Bar, int);
+
+	auto range = [0,0];
+
+	// not 5 because the first Entity is removed by _prime function --> Without!Foo
+	assertEquals(4, em.query!(int, Tuple!(With!Bar, Without!Foo)).range.entities.length);
+	assertRangeEquals(range, em.query!(int, Tuple!(With!Bar, Without!Foo)).map!"*a");
+
+	auto trange = [
+		tuple(Entity(6), 0),
+		tuple(Entity(7), 0)
+	];
+
+	// not 5 because the first Entity is removed by _prime function --> Without!Foo
+	assertEquals(4, em.query!(Tuple!(Entity,int), Tuple!(With!Bar,Without!Foo)).range.entities.length);
+	assertRangeEquals(trange, em.query!(Tuple!(Entity,int), Tuple!(With!Bar,Without!Foo)).map!"tuple(a[0],*a[1])");
+
+	Tuple!(Entity,int*)[] range_; // empty range
+
+	// not 5 because all entities are removes by _prime function --> With!int && Without!int
+	assertEquals(0, em.query!(Tuple!(Entity, int), Tuple!(With!int,Without!int)).range.entities.length);
+	assertRangeEquals(range_, em.query!(Tuple!(Entity, int), Tuple!(With!int,Without!int)));
+
+	assertEquals(0, em.query!(Entity, With!(string)).range.entities.length);
+}

--- a/source/ecs/queryfilter.d
+++ b/source/ecs/queryfilter.d
@@ -1,0 +1,101 @@
+module ecs.queryfilter;
+
+import ecs.entity : Entity;
+import ecs.storage : areComponents, ComponentId, StorageInfo;
+
+import std.meta : allSatisfy, NoDuplicates, staticMap;
+import std.traits : isInstanceOf, TemplateArgsOf;
+import std.typecons : Tuple;
+
+///
+enum areFilterArgs(T ...) = areComponents!T;
+
+///
+enum isFilter(T) = isInstanceOf!(With, T) || isInstanceOf!(Without, T);
+
+/**
+ * Filter entities with the T components
+ */
+struct With(T ...)
+	if (areFilterArgs!T)
+{
+package:
+	this(StorageInfo[] sinfos)
+	{
+		this.sinfos = sinfos;
+	}
+
+	bool opCall(in Entity e)
+	{
+		foreach (sinfo; sinfos)
+			if (!sinfo.has(e))
+				return false;
+
+		return true;
+	}
+
+	StorageInfo[] sinfos;
+}
+
+
+/**
+ * Filter entities without the T components
+ */
+struct Without(T ...)
+	if (areFilterArgs!T)
+{
+package:
+	this(StorageInfo[] sinfos)
+	{
+		this.sinfos = sinfos;
+	}
+
+	bool opCall(in Entity e)
+	{
+		foreach (sinfo; sinfos)
+			if (sinfo.has(e))
+				return false;
+
+		return true;
+	}
+
+	StorageInfo[] sinfos;
+}
+
+
+///
+package struct QueryFilter(Filter)
+	if (isFilter!Filter)
+{
+	this(Filter filter)
+	{
+		this.filter = filter;
+	}
+
+	bool validate(in Entity e) {
+		return filter(e);
+	}
+
+	Filter filter;
+}
+
+
+///
+package struct QueryFilter(FilterTuple)
+	if (isInstanceOf!(Tuple, FilterTuple) && allSatisfy!(isFilter, TemplateArgsOf!(FilterTuple)))
+{
+	this(FilterTuple filters)
+	{
+		this.filters = filters;
+	}
+
+	bool validate(in Entity e) {
+		foreach (filter; filters)
+			if (!filter(e))
+				return false;
+
+		return true;
+	}
+
+	FilterTuple filters;
+}

--- a/source/ecs/queryworld.d
+++ b/source/ecs/queryworld.d
@@ -1,0 +1,132 @@
+module ecs.queryworld;
+
+import ecs.entity;
+import ecs.storage;
+
+import std.format : format;
+import std.range : iota;
+import std.traits : isInstanceOf, TemplateArgsOf;
+import std.typecons : Tuple, tuple;
+
+@safe
+package struct QueryWorld(Output : Entity)
+{
+	this(immutable Entity[] entities)
+	{
+		this.entities = entities;
+	}
+
+	void popFront()
+	{
+		entities = entities[1..$];
+	}
+
+	@property
+	bool empty()
+	{
+		return entities.length == 0;
+	}
+
+	@property
+	Entity front()
+	{
+		return entities[0];
+	}
+
+	immutable(Entity)[] entities;
+}
+
+alias QueryWorld(T : Tuple!Entity) = QueryWorld!Entity;
+
+
+package struct QueryWorld(Output)
+	if (isComponent!Output)
+{
+	this(immutable Entity[] entities, Output[] components)
+	{
+		this.entities = entities;
+		this.components = components;
+	}
+
+	void popFront()
+	{
+		entities = entities[1..$];
+		components = components[1..$];
+	}
+
+	@property
+	bool empty()
+	{
+		return entities.length == 0;
+	}
+
+	@property
+	Output* front()
+	{
+		return &components[0];
+	}
+
+	immutable(Entity)[] entities;
+	Output[] components;
+}
+
+
+@safe
+package struct QueryWorld(OutputTuple)
+	if (isInstanceOf!(Tuple, OutputTuple))
+{
+	this(immutable Entity[] entities, StorageInfo[] sinfos)
+	{
+		this.entities = entities;
+		this.sinfos = sinfos;
+		_prime();
+	}
+
+	void _prime()
+	{
+		while (!empty && !_validate())
+			popFront();
+	}
+
+	bool _validate()
+	{
+		foreach (sinfo; sinfos)
+			if (!sinfo.has(entities[0]))
+				return false;
+
+		return true;
+	}
+
+	void popFront()
+	{
+		do {
+			entities = entities[1..$];
+		} while (!empty && !_validate());
+	}
+
+	@property
+	bool empty()
+	{
+		return entities.length == 0;
+	}
+
+	@property
+	auto front()
+	{
+		auto e = entities[0];
+		enum components = format!q{%(sinfos[%s].get!(Components[%s]).get(entities[0])%|,%)}(Components.length.iota);
+		static if (is(Out[0] == Entity))
+			return mixin(format!q{tuple(entities[0], %s)}(components));
+		else
+			return mixin(format!q{tuple(%s)}(components));
+	}
+
+	alias Out = TemplateArgsOf!OutputTuple;
+	static if (is(Out[0] == Entity))
+		alias Components = Out[1..$];
+	else
+		alias Components = Out;
+
+	immutable(Entity)[] entities;
+	StorageInfo[] sinfos;
+}


### PR DESCRIPTION
Changes:

General
---
* refactored `isComponent` trait - add Tuple, Entity, isSomeChar, !isCopyable restrictions
* added `areComponents` trait

Storage and StorageInfo
---
* added `has` method - checks whether or not and entity exists
* added `entities` method - returns all entities within the `Storage`

EntityManager
---
* refactored `entities` name to `_entities`
* added `entities` @property - returns valid entities
* refactored `_assure` method return type to `size_t` - returns the `StorageInfo` index
* added `_assureStorage` method - takes on the prior behavior of `_assure`
* added `_assureStorageInfo` method - same as `_assureStorage` but returns the `StorageInfo`
* added `query` method - returns a query range

Query, QueryFilter, QueryWorld
---
* added `Query` range - user-end struct for defining queries	
* added `QueryWorld` range:
  * internal range to iterate through the passed components
  * all components passed into this range are returned
  * to iterate through entities the `Entity` type must passed at the beginning
* added `QueryFilter` struct:
  * internal instance used to filter entities based on the filter type
  * only components are allowed as parameters

QueryWorld
---
This range take in `Output` args parameters, `Entity` and `Components`, and iterates through all entities which are associated to those components. Internally an `Entity` range is chosen to be iterated upon. The criteria is simple, given X Components as the `Output` parameters, the one which has the lower size is chosen. By chosen, it means it's from that same Component the `Entity`'s range is taken. This way we minimize the number of iterations to a minimum. The `StorageInfo` of all `Components` is then appended to a new array which is passed to the `QueryWorld` instance as well as the `Entity` array. From that point it's a normal range.

QueryFilter
---
This struct is responsible for validating an entity based on a filter type. At the moment the only two filters available are `With` and `Without`. The `With` filter returns true if all `Components` are associated to the `Entity` being evaluated, `Without` is the opposing. `Components` added here are not returned to the `Output`, this way it's possible to easily query multiple `Components` and iterate to a few of them. The `With` filter has a special functionality internally. Because it's behavior is the same as the `Components` passed in `QueryWorld` without returning them, it's `Components` are used to find the the lowest sized `Storage`.

Query
---
This struct is the end-user utility to define a query range. Bellow is a simple example of how to use it:

```d
void collisonSystem(Query!(Tuple!(Entity, Position, Velocity)) query, double delta)
{
	foreach (e, pos, vel; query)
	{
		*pos.x += *vel.x * delta;
		*pos.y += *vel.y * delta;
	}
}

void drawSystem(Query!(Tuple!(Position, Sprite), With!RigidBody) query)
{
	foreach (pos, sprite; query)
		draw(*pos, *sprite)
}

void crawlerUndeadSystem(Query!(Entity, Tuple!(With!(Undead, Crawler), Without!Fly)) query)
{
	foreach (e; query) { ... }
}
```

```d
struct Position
{
	double x = 0, y = 0;
}

struct Velocity
{
	double x = 0, y = 0;
}

...
```

```d
void main()
{
	auto em = EntityManager();
	
	// gen entities
	...

	// somedelta is a representative variable
	collisionSystem(em.query!(Tuple(Entity,Position,Velocity)), somedelta);

	// Sprite and RigidBody are representative Components
	collisionSystem(em.query!(Tuple(Position,Sprite), With!(RigidBody)));

	// Undead, Crawler and Fly are representative Components
	crawlerUndeadSystem(em.query!(Entity, Tuple!(With!(Undead, Crawler), Without!Fly)));
}
```
